### PR TITLE
propertyNames instead of Column Names

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -508,25 +508,31 @@ MsSQL.prototype.fromDatabase = function (model, data) {
   if (!data) {
     return null;
   }
-  // create an "id" property in the data for backwards compatibility with juggling-db
-  // data.id = data[this.idName(model)];
   var props = this._models[model].properties;
-  //look for date values in the data, convert them from the database to a javascript date object
-  Object.keys(data).forEach(function (key) {
+  var json = {};
+  for (var p in props) {
+    var key = this.column(model, p);
     var val = data[key];
-    if (props[key]) {
-      if (props[key].type.name === 'Boolean' && val !== null) {
+    if (val === undefined) {
+      continue;
+    }
+    if (val === null) {
+      json[p] = null;
+      continue;
+    }
+    if (props[p]) {
+      if (props[p].type.name === 'Boolean' && val !== null) {
         val = (true && val); //convert to a boolean type from number
       }
-      if (props[key].type.name === 'Date' && val !== null) {
-        if(!(val instanceof Date)) {
+      if (props[p].type.name === 'Date' && val !== null) {
+        if (!(val instanceof Date)) {
           val = new Date(val.toString());
         }
       }
     }
-    data[key] = val;
-  });
-  return data;
+    json[p] = val;
+  }
+  return json;
 };
 
 MsSQL.prototype.escapeName = function (name) {
@@ -655,13 +661,14 @@ MsSQL.prototype.all = function (model, filter, callback) {
     if (err) return callback(err);
 
     //convert database types to js types
-    data = self.fromDatabase(model, data);
-
+    var objs = data.map(function (obj) {
+      return self.fromDatabase(model, obj);
+    });
     //check for eager loading relationships
     if (filter && filter.include) {
-      this._models[model].model.include(data, filter.include, callback);
+      this._models[model].model.include(objs, filter.include, callback);
     } else {
-      callback(null, data);
+      callback(null, objs);
     }
   }.bind(this));
 


### PR DESCRIPTION
Use the models property names in the response object instead of the
column names.
Taken from loopback-connector-mysql and refactored for mssql
Todo: check if there are consequences for MsSQL.prototype.find
