### PR TITLE
handle precision and scale

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -1275,6 +1275,11 @@ MsSQL.prototype.columnDataType = function (model, property) {
   }
   var colLength = columnMetadata && columnMetadata.dataLength || prop.length;
   if (colType) {
+    var dataPrecision = columnMetadata.dataPrecision;
+    var dataScale = columnMetadata.dataScale;
+    if (dataPrecision && dataScale) {
+      return colType + '(' + dataPrecision + ', ' + dataScale + ')';
+    }
     return colType + (colLength ? '(' + colLength + ')' : '');
   }
   return datatype(prop);


### PR DESCRIPTION
The SQL data type [decimal](http://msdn.microsoft.com/en-us/library/ms187746.aspx) takes 'precision' and 'scale' options.  Currently the loopback code does not support these options.  These few lines of code represent a naive implementation.

I'm not certain how to test this.  I had thought to call MsSQL.prototype.propertySettingsSQL, but this function is private to the adapter and not exposed via any export.  I think being able to unit test some of the SQL building functions would be advantageous, but clearly would require code restructure.

Also, I am using these options in context of the `decimal` data type, but I imagine there could be other data types that use them as well.

Just out of curiosity, is the ability to supply SQL-specific options to the schema type supported?  It seems to have been taken out of the documentation.  It was present [in 1.x](http://docs.strongloop.com/display/LB1/SQL+Server+connector), but is no longer present [in 2.x](http://docs.strongloop.com/display/public/LB/SQL+Server+connector).  This is important functionality for certain applications - for instance the project I'm working on needs to handle money and accounting data.  Having control over the precision/scale is very useful.
