### PR TITLE
fixed race condition causing incorrect IDs to be reported on INSERT

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -153,8 +153,8 @@ MsSQL.prototype.create = function (model, data, callback) {
   var fieldsAndData = this.buildInsert(model, data);
   var tblName = this.tableEscaped(model);
   var sql = "INSERT INTO " + tblName + " (" + fieldsAndData.fields + ")" + MsSQL.newline;
-  sql += "VALUES (" + fieldsAndData.paramPlaceholders + ");" + MsSQL.newline;
-  sql += "SELECT IDENT_CURRENT('" + tblName + "') AS insertId;";
+  sql += "OUTPUT INSERTED." + modelPKID + " AS insertId" + MsSQL.newline;
+  sql += "VALUES (" + fieldsAndData.paramPlaceholders + ");";
 
   this.query(sql, fieldsAndData.params, function (err, results) {
     if (err) {


### PR DESCRIPTION
When sending multiple INSERT operations to the MSSQL driver asynchronously, sometimes the IDs are incorrectly reported.  I have observed 1) all the IDs being the same, 2) some IDs misreported, others correct.  This is because MsSQL.prototype.create contains two SQL commands, the sum of which is not atomic.  This change makes them atomic by wrapping them in a transaction.

Correct results are really important here - this was causing my foreign-key relationships to be configured incorrectly, which is a loss of data integrity.

I don't see a strong rationale for testing this, as it would be difficult to replicate, and would introduce indeterminacy into your test suite.
