### PR TITLE
Fix: empty inq/nin function correctly

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -769,7 +769,7 @@ MsSQL.prototype._buildWhere = function (model, conds) {
       var condType = Object.keys(conds[key])[0];
       var sqlCond = keyEscaped;
       if ((condType === 'inq' || condType === 'nin') && val.length === 0) {
-        cs.push(condType === 'inq' ? 0 : 1);
+        cs.push(condType === 'inq' ? '0 = 1' : '1 = 1');
         return true;
       }
       if (condType === "max") {

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -134,4 +134,24 @@ describe('mssql connector', function () {
       });
     });
 
+  it('should perform an empty inq',
+    function(done) {
+      Post.find({where: {id: {inq: []}}}, function(err, p) {
+        should.not.exist(err);
+        should.exist(p);
+        p.should.have.length(0);
+        done();
+      });
+    });
+
+  it('should perform an empty nin',
+    function(done) {
+      Post.find({where: {id: {nin: []}}}, function(err, p) {
+        should.not.exist(err);
+        should.exist(p);
+        p.should.have.length(4);
+        done();
+      });
+    });
+
 });


### PR DESCRIPTION
This fix makes the query:

```javascript
{ id: { inq: [] } } }
```

Produce:

```sql
WHERE 0 = 1
```

And the query:

```javascript
{ id: { nin: [] } } }
```

Produces:

```sql
WHERE 1 = 1
```

The previous behavior resulted in invalid SQL.  More details here:

https://github.com/strongloop/loopback-connector-mssql/issues/19