### PR TITLE
Add PARTITION BY to T-SQL query for include filter

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -342,15 +342,39 @@ function buildLimit(limit, offset) {
   return sql;
 }
 
+MsSQL.prototype.buildPartitionByFirst = function(model, where) {
+  if (!where) {
+    return '';
+  }
+
+  if (typeof where !== 'object' || Array.isArray(where)) {
+    return '';
+  }
+
+  for (var key in where) {
+    if (key === 'and' || key === 'or') {
+      return '';
+    }
+    var firstColumnName = this.columnEscaped(model, key);
+    break;
+  }
+
+  return 'PARTITION BY ' + firstColumnName;
+};
+
 MsSQL.prototype.buildColumnNames = function(model, filter) {
   var columnNames = this.invokeSuper('buildColumnNames', model, filter);
   if (filter.limit || filter.offset || filter.skip) {
     var orderBy = this.buildOrderBy(model, filter.order);
     var orderClause = '';
+    var partitionByClause = '';
+    if(filter.where) {
+      partitionByClause = this.buildPartitionByFirst(model, filter.where);
+    }
     if (orderBy) {
-      orderClause = 'OVER (' + orderBy + ') ';
+      orderClause = 'OVER (' + partitionByClause + ' ' + orderBy + ') ';
     } else {
-      orderClause = 'OVER (ORDER BY (SELECT 1)) ';
+      orderClause = 'OVER (' + partitionByClause + ' ' + 'ORDER BY (SELECT 1)) ';
     }
     columnNames += ',ROW_NUMBER() ' + orderClause + 'AS RowNum';
   }


### PR DESCRIPTION
This is to replace my previous pull request https://github.com/strongloop/loopback-connector-mssql/pull/59, which was incorrect.

The request depends on committing the changes in my loopback-connector pull request https://github.com/strongloop/loopback-connector/pull/34.

This change is necessary when I want to query a dimension in datawarehouse and include the latest fact per each dimension record. I have two models, fact and dimension, which connected through one-to-many relation on dimensionId property, and my dimension.find's filter looks as following:
{
      where:{ 
        dimensionId:{
         inq:[1,2,3]
        } 
      },
      include:[ {
         relation:"facts", 
         scope:{
           order:"factId DESC", 
           limit:1
         }
      }]
}

Currently, buildColumnNames function generates the following T-SQL for such include filter:

SELECT * FROM 
(
	SELECT ..., ROW_NUMBER() OVER (ORDER BY factId DESC) AS RowNum 
	FROM Fact
	WHERE dimensionId IN (1,2,3)
) AS S
WHERE S.RowNum > 0 AND S.RowNum <= 1

which works incorrectly. In order to get the latest fact by above query, it should have 'PARTITION BY dimensionId' clause and look as follow:

SELECT * FROM 
(
	SELECT ..., ROW_NUMBER() OVER (PARTITION BY dimensionId ORDER BY factId DESC) AS RowNum 
	FROM Fact
	WHERE dimensionId IN (1,2,3)
) AS S
WHERE S.RowNum > 0 AND S.RowNum <= 1

The change preserves the existing pagination functionality and only applies when the model's find() filter argument has include subfilter.
