### PR TITLE
Remove regenerator from babel-runtime and bundle mssql

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "loopback-connector": "^2.1.0",
     "mssql": "^3.1.1"
   },
+  "bundledDependencies": ["mssql"],
   "devDependencies": {
     "bluebird": "^3.3.3",
     "loopback-datasource-juggler": "^2.28.0",
@@ -27,7 +28,8 @@
     "sinon": "^1.15.4"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --timeout 5000 -R spec"
+    "test": "./node_modules/.bin/mocha --timeout 5000 -R spec",
+    "prepublish": "node remove-regenerator.js"
   },
   "repository": {
     "type": "git",

--- a/remove-regenerator.js
+++ b/remove-regenerator.js
@@ -1,0 +1,19 @@
+/**
+ * This script removes regenerator bundled with babel-runtime
+ */ 
+var fs = require('fs');
+try {
+  var index = require.resolve('babel-runtime/regenerator/index.js');
+  var runtime = require.resolve(
+    'babel-runtime/regenerator/runtime.js');
+  if (index) {
+    fs.unlink(index, function(err) {
+      if (err) console.error(err);
+      if (runtime) fs.unlink(runtime, function(err) {
+        if (err) console.error(err);
+      });;
+    });
+  }
+} catch (err) {
+  // Ignore
+}


### PR DESCRIPTION
This PR removes regenerator from babel-runtime dependency and bundle `mssql` module.
