### PR TITLE
use varchar rather than uniqueidentifier for id fix closes #53

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -333,7 +333,7 @@ function mixinMigration(MsSQL) {
         } else if (idProp.type === String) {
           if (idProp.generated !== false) {
             sql.push(self.columnEscaped(model, modelPKID) +
-              ' [uniqueidentifier] DEFAULT newid() NOT NULL');
+              ' [varchar](64) DEFAULT newid() NOT NULL');
           } else {
             sql.push(self.columnEscaped(model, modelPKID) + ' ' +
               self.propertySettingsSQL(model, prop) + ' DEFAULT newid()');


### PR DESCRIPTION
Using uniqueidentifier as the id column type causes an exception when an AccessToken is created by Strongloop.
Instead use [varchar](64)

The exception thrown is "RequestError: Conversion failed when converting from a character string to uniqueidentifier"
