### PR TITLE
Fixes #79 discovery of primary keys

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -224,9 +224,9 @@ function mixinDiscovery(MsSQL) {
     var sql = 'SELECT kc.table_schema AS "owner", ' +
       'kc.table_name AS "tableName", kc.column_name AS "columnName", kc.ordinal_position' +
       ' AS "keySeq", kc.constraint_name AS "pkName" FROM' +
-      ' INFORMATION_SCHEMA.key_column_usage kc' +
-      ' JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc' +
-      ' ON kc.table_name = tc.table_name AND kc.table_schema = tc.table_schema' +
+      ' information_schema.key_column_usage kc' +
+      ' JOIN information_schema.table_constraints tc' +
+      ' ON kc.table_name = tc.table_name AND kc.constraint_name = tc.constraint_name AND kc.table_schema = tc.table_schema' +
       ' WHERE tc.constraint_type=\'PRIMARY KEY\' AND kc.ordinal_position IS NOT NULL';
 
     if (owner) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -224,8 +224,8 @@ function mixinDiscovery(MsSQL) {
     var sql = 'SELECT kc.table_schema AS "owner", ' +
       'kc.table_name AS "tableName", kc.column_name AS "columnName", kc.ordinal_position' +
       ' AS "keySeq", kc.constraint_name AS "pkName" FROM' +
-      ' information_schema.key_column_usage kc' +
-      ' JOIN information_schema.table_constraints tc' +
+      ' INFORMATION_SCHEMA.key_column_usage kc' +
+      ' JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc' +
       ' ON kc.table_name = tc.table_name AND kc.constraint_name = tc.constraint_name AND kc.table_schema = tc.table_schema' +
       ' WHERE tc.constraint_type=\'PRIMARY KEY\' AND kc.ordinal_position IS NOT NULL';
 

--- a/test/discover.test.js
+++ b/test/discover.test.js
@@ -148,6 +148,72 @@ describe('Discover model primary keys', function() {
       }
     });
   });
+
+  it('should return just the primary keys and not the foreign keys for inventory', function(done) {
+    db.discoverPrimaryKeys('inventory', function(err, models) {
+      if (err) {
+        console.error(err);
+        done(err);
+      } else {
+        models.forEach(function(m) {
+          // console.dir(m);
+          assert(m.tableName === 'inventory');
+          assert(m.columnName === 'id');
+          assert(m.pkName.match(/_pk$/));
+        });
+        done(null, models);
+      }
+    });
+  });
+
+  it('should return just the primary keys and not the foreign keys for dbo.inventory', function(done) {
+    db.discoverPrimaryKeys('inventory', {owner: 'dbo'}, function(err, models) {
+      if (err) {
+        console.error(err);
+        done(err);
+      } else {
+        models.forEach(function(m) {
+          // console.dir(m);
+          assert(m.tableName === 'inventory');
+          assert(m.columnName === 'id');
+          assert(m.pkName === 'inventory_pk');
+        });
+        done(null, models);
+      }
+    });
+  });
+  it('should return the primary key for version which consists of two columns', function(done) {
+    db.discoverPrimaryKeys('version', function(err, models) {
+      if (err) {
+        console.error(err);
+        done(err);
+      } else {
+        assert(models.length === 2);
+        models.forEach(function(m) {
+          // console.dir(m);
+          assert(m.tableName === 'version');
+          assert(m.pkName.match(/_pk$/));
+        });
+        done(null, models);
+      }
+    });
+  });
+  it('should return the primary key for dbo.version which consists of two columns', function(done) {
+    db.discoverPrimaryKeys('version', {owner: 'dbo'}, function(err, models) {
+      if (err) {
+        console.error(err);
+        done(err);
+      } else {
+        assert(models.length === 2);
+        models.forEach(function(m) {
+          // console.dir(m);
+          assert(m.tableName === 'version');
+          assert(m.pkName.match(/_pk$/));
+        });
+        done(null, models);
+      }
+    });
+  });
 });
 
 describe('Discover model foreign keys', function() {

--- a/test/tables.sql
+++ b/test/tables.sql
@@ -4,6 +4,9 @@ DROP TABLE inventory;
 IF OBJECT_ID('dbo.reservation', 'U') IS NOT NULL
 DROP TABLE reservation;
 
+IF OBJECT_ID('dbo.version', 'U') IS NOT NULL
+DROP TABLE version;
+
 IF OBJECT_ID('dbo.customer', 'U') IS NOT NULL
 DROP TABLE customer;
 
@@ -15,9 +18,6 @@ DROP TABLE product;
 
 IF OBJECT_ID('dbo.session', 'U') IS NOT NULL
 DROP TABLE session;
-
-IF OBJECT_ID('dbo.version', 'U') IS NOT NULL
-DROP TABLE version;
 
 IF OBJECT_ID('sa.movies', 'U') IS NOT NULL
 DROP TABLE sa.movies;

--- a/test/tables.sql
+++ b/test/tables.sql
@@ -1,3 +1,6 @@
+IF OBJECT_ID('dbo.inventory', 'U') IS NOT NULL
+DROP TABLE inventory;
+
 IF OBJECT_ID('dbo.reservation', 'U') IS NOT NULL
 DROP TABLE reservation;
 
@@ -12,9 +15,6 @@ DROP TABLE product;
 
 IF OBJECT_ID('dbo.session', 'U') IS NOT NULL
 DROP TABLE session;
-
-IF OBJECT_ID('dbo.version', 'U') IS NOT NULL
-DROP TABLE version;
 
 IF OBJECT_ID('sa.movies', 'U') IS NOT NULL
 DROP TABLE sa.movies;
@@ -96,7 +96,7 @@ GO
 	uid varchar(1024),
 	ttl integer
    ) ;
-
+  
   create table version
    (	product_id varchar(64) not null,
 	version integer not null

--- a/test/tables.sql
+++ b/test/tables.sql
@@ -1,6 +1,3 @@
-IF OBJECT_ID('dbo.inventory', 'U') IS NOT NULL
-DROP TABLE inventory;
-
 IF OBJECT_ID('dbo.reservation', 'U') IS NOT NULL
 DROP TABLE reservation;
 
@@ -15,6 +12,9 @@ DROP TABLE product;
 
 IF OBJECT_ID('dbo.session', 'U') IS NOT NULL
 DROP TABLE session;
+
+IF OBJECT_ID('dbo.version', 'U') IS NOT NULL
+DROP TABLE version;
 
 IF OBJECT_ID('sa.movies', 'U') IS NOT NULL
 DROP TABLE sa.movies;
@@ -95,6 +95,11 @@ GO
    (	id varchar(64) not null,
 	uid varchar(1024),
 	ttl integer
+   ) ;
+
+  create table version
+   (	product_id varchar(64) not null,
+	version integer not null
    ) ;
 
   create table movies
@@ -721,12 +726,13 @@ insert into product (id,name,audible_range,effective_range,rounds,extras,fire_mo
 insert into product (id,name,audible_range,effective_range,rounds,extras,fire_modes) values ('2','g17',53,75,15,'flashlight','single');
 insert into product (id,name,audible_range,effective_range,rounds,extras,fire_modes) values ('5','m9 sd',0,75,15,'silenced','single');
 
-  alter table inventory add primary key (id);
-  alter table location add primary key (id);
+  alter table inventory add constraint inventory_pk primary key (id);
+  alter table location add constraint location_pk primary key (id);
 
-  alter table customer add primary key (id);
-  alter table product add primary key (id);
-  alter table session add primary key (id);
+  alter table customer add constraint customer_pk primary key (id);
+  alter table product add constraint product_pk primary key (id);
+  alter table session add constraint session_pk primary key (id);
+  alter table version add constraint version_pk primary key (product_id, version);
 
   alter table inventory add constraint location_fk foreign key (location_id) references location (id);
   alter table inventory add constraint product_fk foreign key (product_id) references product (id);
@@ -734,6 +740,7 @@ insert into product (id,name,audible_range,effective_range,rounds,extras,fire_mo
   alter table reservation add constraint reservation_customer_fk foreign key (customer_id) references customer (id);
   alter table reservation add constraint reservation_location_fk foreign key (location_id) references location (id);
   alter table reservation add constraint reservation_product_fk foreign key (product_id) references product (id);
+  alter table version add constraint version_product_fk foreign key (product_id) references product (id);
 
 GO
 

--- a/test/tables.sql
+++ b/test/tables.sql
@@ -16,6 +16,9 @@ DROP TABLE product;
 IF OBJECT_ID('dbo.session', 'U') IS NOT NULL
 DROP TABLE session;
 
+IF OBJECT_ID('dbo.version', 'U') IS NOT NULL
+DROP TABLE version;
+
 IF OBJECT_ID('sa.movies', 'U') IS NOT NULL
 DROP TABLE sa.movies;
 


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-connector-mssql/issues/79

The query executed in lib/discovery.js **queryForPrimaryKeys returns not only primary keys but also foreign keys**. Which in turn causes schemas to be generated with foreign key properties with an id property > 0. Which in turn generates an error when updating model instance foreign key properties through updateAttributes: _"id property (some foreign key column) cannot be updated from A to
 B"_

Root cause is the query defined in the queryForPrimaryKeys function on the test table inventory.

```
SELECT
  kc.table_schema     AS "owner", 
  kc.table_name       AS "tableName",
  kc.column_name      AS "columnName",
  kc.ordinal_position AS "keySeq",
  kc.constraint_name  AS "pkName"
FROM information_schema.table_constraints tc
JOIN information_schema.key_column_usage kc
  ON kc.table_name      = tc.table_name
 AND kc.table_schema    = tc.table_schema
WHERE tc.constraint_type  ='PRIMARY KEY'
  AND kc.ordinal_position IS NOT NULL
  AND kc.table_schema     = 'dbo'
  AND kc.table_name       = 'inventory'
ORDER BY kc.table_schema, kc.table_name, kc.ordinal_position;
```

which returns:

```
owner tableName columnName  keySeq pkName                        
dbo   inventory location_id 1      location_fk                   
dbo   inventory id          1      PK__inventor__3213E83F07F6335A
dbo   inventory product_id  1      product_fk 
```

But it should return:

```
owner tableName columnName  keySeq pkName                        
dbo   inventory id          1      PK__inventor__3213E83F07F6335A
```

This PR adds the missing join-on criterium.

```
JOIN information_schema.key_column_usage kc
  ON kc.table_name      = tc.table_name
 AND kc.constraint_name = tc.constraint_name -- < the missing criterium
 AND kc.table_schema    = tc.table_schema
```

Without that criterium you're getting every key column for the same table which are all foreign keys too.
