### PR TITLE
Fixed multiple primary keys and only one belongsTo relation generated from mssql juggler 2.19.0

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -272,7 +272,7 @@ function mixinDiscovery(MsSQL) {
   function queryForPrimaryKeys(owner, table) {
     var sql = 'SELECT kc.table_schema AS "owner", ' +
       'kc.table_name AS "tableName", kc.column_name AS "columnName", kc.ordinal_position' +
-      ' AS "keySeq", kc.constraint_name AS "pkName" FROM' +
+      ' AS "keySeq", kc.constraint_name AS "pkName", COLUMNPROPERTY(object_id(CONCAT(kc.TABLE_SCHEMA, \'.\', kc.TABLE_NAME)), kc.COLUMN_NAME, \'IsIdentity\') AS isIdentity FROM' +
       ' information_schema.key_column_usage kc' +
       ' JOIN information_schema.table_constraints tc' +
       ' ON kc.table_name = tc.table_name AND kc.table_schema = tc.table_schema AND kc.constraint_name = tc.constraint_name' +
@@ -285,6 +285,7 @@ function mixinDiscovery(MsSQL) {
       sql += ' AND kc.table_name=\'' + table + '\'';
     }
     sql += ' ORDER BY kc.table_schema, kc.table_name, kc.ordinal_position';
+
     return sql;
   }
 
@@ -386,25 +387,31 @@ WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='PR_Publication'
    * @returns {string}
    */
   function queryExportedForeignKeys(owner, table) {
-    var sql = 'SELECT kcu.constraint_name AS "fkName", kcu.table_schema AS "fkOwner", kcu.table_name AS "fkTableName",' +
-      ' kcu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",' +
-      ' \'PK\' AS "pkName", ccu.table_schema AS "pkOwner",' +
-      ' ccu.table_name AS "pkTableName", ccu.column_name AS "pkColumnName"' +
-      ' FROM' +
-      ' information_schema.constraint_column_usage ccu' +
-      ' JOIN information_schema.key_column_usage kcu' +
-      ' ON ccu.constraint_schema = kcu.constraint_schema AND ccu.constraint_name = kcu.constraint_name' +
-      ' WHERE kcu.ordinal_position IS NOT NULL';
-    if (owner) {
-      sql += ' and ccu.table_schema=\'' + owner + '\'';
-    }
-    if (table) {
-      sql += ' and ccu.table_name=\'' + table + '\'';
-    }
-    sql += ' order by kcu.table_schema, kcu.table_name, kcu.ordinal_position';
 
+// SELECT DISTINCT 
+// schema_name(fk.schema_id) as fkOwner, ccu.table_name as fkTableName,
+// ccu.column_name AS fkColumnName, c.ordinal_position as fkSeq, count(ccu2.column_name) as pkComposite
+// FROM sys.foreign_keys fk
+// INNER JOIN information_schema.key_column_usage ccu ON fk.name = ccu.constraint_name
+// INNER JOIN information_schema.columns c ON c.table_name=ccu.table_name AND c.column_name =ccu.column_name
+// LEFT JOIN information_schema.key_column_usage ccu2 ON ccu2.table_name=ccu.table_name AND ccu2.Constraint_name LIKE 'PK%'
+// WHERE fk.Referenced_object_id = object_id('dbo.PR_Production','U')
+// GROUP BY fk.schema_id , ccu.table_name, ccu.column_name, c.ordinal_position
+
+    var sql = "SELECT DISTINCT" +
+      " schema_name(fk.schema_id) as fkOwner, ccu.table_name as fkTableName," +
+      " ccu.column_name AS fkColumnName, c.ordinal_position as fkSeq, count(ccu2.column_name) as pkComposite" +
+      " FROM sys.foreign_keys fk"+
+      " INNER JOIN information_schema.constraint_column_usage ccu ON fk.name = ccu.constraint_name"+
+      " INNER JOIN information_schema.columns c ON c.table_name=ccu.table_name AND c.column_name =ccu.column_name"+
+      " LEFT JOIN information_schema.key_column_usage ccu2 ON ccu2.table_name=ccu.table_name AND ccu2.Constraint_name LIKE 'PK%'"+
+      " WHERE fk.Referenced_object_id = object_id('"+owner+"."+table+"','U')" +
+      " GROUP BY fk.schema_id , ccu.table_name, ccu.column_name, c.ordinal_position";
+
+    // console.log(sql);
     return sql;
   }
+
 
   /**
    * Discover foreign keys that reference to the primary key of this table
@@ -418,10 +425,32 @@ WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='PR_Publication'
     table = args.table;
     options = args.options;
     cb = args.cb;
-
     var sql = queryExportedForeignKeys(owner, table);
     this.execute(sql, cb);
   };
+
+  function queryManyToManyRelations(owner, table){
+
+    var sql = "SELECT object_name(fk.parent_object_id) as throughTableName, object_name(fk2.referenced_object_id) as fkTableName, ccu.column_name as fkColumnName, ccu2.column_name as throughColumnName"+
+      " FROM sys.foreign_keys fk"+
+      " INNER JOIN sys.foreign_keys fk2 ON fk.parent_object_id = fk2.parent_object_id"+
+      " INNER JOIN information_schema.constraint_column_usage ccu ON fk.name = ccu.constraint_name"+
+      " INNER JOIN information_schema.constraint_column_usage ccu2 ON fk2.name = ccu2.constraint_name"+
+      " WHERE fk.Referenced_object_id = object_id('"+owner+"."+table+"','U') AND fk2.referenced_object_id <> object_id('"+owner+"."+table+"','U')";
+
+    return sql;
+  }
+
+  MsSQL.prototype.discoverManyToManyRelations = function(table, options, cb){
+    var args = getArgs(table, options, cb);
+    var owner = args.owner;
+    table = args.table;
+    options = args.options;
+    cb = args.cb;
+    var sql = queryManyToManyRelations(owner, table);
+    this.execute(sql, cb);
+  };
+
 
   function mysqlDataTypeToJSONType(mysqlType, dataLength) {
     var type = mysqlType.toUpperCase();

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -338,10 +338,10 @@ WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='PR_Publication'
    */
   function queryForeignKeys(owner, table) {
     var sql =
-      'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName",  AS ccu.table_name "fkTableName",' +
+      'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName", ccu.table_name AS "fkTableName",' +
       ' ccu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",' +
       ' ccu.table_schema AS "pkOwner", \'PK\' AS "pkName", ' +
-      ' OBJECT_NAME (f.referenced_object_id) AS "pkTableName",  AS kcu.column_name "pkColumnName"' +
+      ' OBJECT_NAME (f.referenced_object_id) AS "pkTableName", kcu.column_name AS "pkColumnName"' +
       ' FROM information_schema.table_constraints tc' +
       ' JOIN information_schema.key_column_usage AS kcu' +
       ' ON tc.constraint_schema = kcu.constraint_schema AND tc.constraint_name = kcu.constraint_name' +

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -338,10 +338,10 @@ WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='PR_Publication'
    */
   function queryForeignKeys(owner, table) {
     var sql =
-      'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName", OBJECT_NAME (f.referenced_object_id) AS "fkTableName",' +
-      ' kcu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",' +
+      'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName",  AS ccu.table_name "fkTableName",' +
+      ' ccu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",' +
       ' ccu.table_schema AS "pkOwner", \'PK\' AS "pkName", ' +
-      ' ccu.table_name AS "pkTableName", ccu.column_name AS "pkColumnName"' +
+      ' OBJECT_NAME (f.referenced_object_id) AS "pkTableName",  AS kcu.column_name "pkColumnName"' +
       ' FROM information_schema.table_constraints tc' +
       ' JOIN information_schema.key_column_usage AS kcu' +
       ' ON tc.constraint_schema = kcu.constraint_schema AND tc.constraint_name = kcu.constraint_name' +

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -358,7 +358,6 @@ WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='PR_Publication'
     if (table) {
       sql += ' AND tc.table_name=\'' + table + '\'';
     }
-    console.log(sql);
     return sql;
   }
 

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -275,7 +275,7 @@ function mixinDiscovery(MsSQL) {
       ' AS "keySeq", kc.constraint_name AS "pkName" FROM' +
       ' information_schema.key_column_usage kc' +
       ' JOIN information_schema.table_constraints tc' +
-      ' ON kc.table_name = tc.table_name AND kc.table_schema = tc.table_schema' +
+      ' ON kc.table_name = tc.table_name AND kc.table_schema = tc.table_schema AND kc.constraint_name = tc.constraint_name' +
       ' WHERE tc.constraint_type=\'PRIMARY KEY\' AND kc.ordinal_position IS NOT NULL';
 
     if (owner) {
@@ -323,11 +323,22 @@ function mixinDiscovery(MsSQL) {
    JOIN information_schema.constraint_column_usage AS ccu
    ON ccu.constraint_name = tc.constraint_name
    WHERE constraint_type = 'FOREIGN KEY' AND tc.table_name='mytable';
+SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName", OBJECT_NAME (f.referenced_object_id) AS "fkTableName", 
+kcu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq", ccu.table_schema AS "pkOwner", 'PK' AS "pkName",  ccu.table_name AS "pkTableName", ccu.column_name AS "pkColumnName" 
+FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage AS kcu 
+ON tc.constraint_schema = kcu.constraint_schema AND tc.constraint_name = kcu.constraint_name 
+JOIN information_schema.constraint_column_usage ccu 
+ON ccu.constraint_schema = tc.constraint_schema AND ccu.constraint_name = tc.constraint_name
+JOIN sys.foreign_keys AS f
+ON f.name =  tc.constraint_name
+JOIN sys.foreign_key_columns AS fc   
+ON f.object_id = fc.constraint_object_id
 
+WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='PR_Publication'
    */
   function queryForeignKeys(owner, table) {
     var sql =
-      'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName", tc.table_name AS "fkTableName",' +
+      'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName", OBJECT_NAME (f.referenced_object_id) AS "fkTableName",' +
       ' kcu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",' +
       ' ccu.table_schema AS "pkOwner", \'PK\' AS "pkName", ' +
       ' ccu.table_name AS "pkTableName", ccu.column_name AS "pkColumnName"' +
@@ -336,6 +347,10 @@ function mixinDiscovery(MsSQL) {
       ' ON tc.constraint_schema = kcu.constraint_schema AND tc.constraint_name = kcu.constraint_name' +
       ' JOIN information_schema.constraint_column_usage ccu' +
       ' ON ccu.constraint_schema = tc.constraint_schema AND ccu.constraint_name = tc.constraint_name' +
+      ' JOIN sys.foreign_keys AS f' +
+      ' ON f.name =  tc.constraint_name' +
+      ' JOIN sys.foreign_key_columns AS fc' +  
+      ' ON f.object_id = fc.constraint_object_id' +
       ' WHERE tc.constraint_type = \'FOREIGN KEY\'';
     if (owner) {
       sql += ' AND tc.table_schema=\'' + owner + '\'';
@@ -343,6 +358,7 @@ function mixinDiscovery(MsSQL) {
     if (table) {
       sql += ' AND tc.table_name=\'' + table + '\'';
     }
+    console.log(sql);
     return sql;
   }
 


### PR DESCRIPTION
There was a bug where only one belongsTo relation is generated and many foreignkeys were flaggued with identity attribute (primary key). 