### PR TITLE
Update mocha timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "./node_modules/.bin/mocha --timeout 5000 -R spec",
+    "test": "./node_modules/.bin/mocha --timeout 9999 -R spec",
     "posttest": "npm run lint",
     "prepublish": "node remove-regenerator.js"
   },


### PR DESCRIPTION
### Description
Lots of tests do timeout because of the timeout lapse given is too short. 
it needs to be increased. 

