### PR TITLE
Add test case for order by random

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -504,6 +504,14 @@ MsSQL.prototype.ping = function(cb) {
   this.execute('SELECT 1 AS result', cb);
 };
 
+/**
+ * Build order by random
+ * @returns {string} the order by rand() statement
+ */
+MsSQL.prototype.buildOrderByRandom = function() {
+  return 'ORDER BY NEWID()';
+};
+
 require('./discovery')(MsSQL, mssql);
 require('./migration')(MsSQL, mssql);
 require('./transaction')(MsSQL, mssql);

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -240,12 +240,12 @@ describe('mssql connector', function() {
   });
 
   it('should support order with random sorting', function(done) {
-    Post.find({order: 'rand'}, function(err, randomPosts1) {
+    Post.find({order: '${random}'}, function(err, randomPosts1) {
       should.not.exists(err);
       var order1 = randomPosts1.map(function(u) { return u.id; });
       (order1.length).should.eql(randomPosts1.length);
       order1.should.containEql(1, 2, 3);
-      Post.find({order: 'rand'}, function(err, randomPosts2) {
+      Post.find({order: '${random}'}, function(err, randomPosts2) {
         should.not.exist(err);
         var order2 = randomPosts2.map(function(u) { return u.id; });
         (order2.length).should.eql(randomPosts2.length);

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -243,14 +243,12 @@ describe('mssql connector', function() {
     Post.find({order: 'rand'}, function(err, randomPosts1) {
       should.not.exists(err);
       var order1 = randomPosts1.map(function(u) { return u.id; });
-      console.log(order1);
       (order1.length).should.eql(randomPosts1.length);
       order1.should.containEql(1, 2, 3);
       Post.find({order: 'rand'}, function(err, randomPosts2) {
         should.not.exist(err);
         var order2 = randomPosts2.map(function(u) { return u.id; });
         (order2.length).should.eql(randomPosts2.length);
-        console.log(order2);
         order2.should.containEql(1, 2, 3);
          //Though it is a possibility, but probability is very low.
         should(order1).not.eql(order2);

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -239,6 +239,26 @@ describe('mssql connector', function() {
       });
   });
 
+  it('should support order with random sorting', function(done) {
+    Post.find({order: 'rand'}, function(err, randomPosts1) {
+      should.not.exists(err);
+      var order1 = randomPosts1.map(function(u) { return u.id; });
+      console.log(order1);
+      (order1.length).should.eql(randomPosts1.length);
+      order1.should.containEql(1, 2, 3);
+      Post.find({order: 'rand'}, function(err, randomPosts2) {
+        should.not.exist(err);
+        var order2 = randomPosts2.map(function(u) { return u.id; });
+        (order2.length).should.eql(randomPosts2.length);
+        console.log(order2);
+        order2.should.containEql(1, 2, 3);
+         //Though it is a possibility, but probability is very low.
+        should(order1).not.eql(order2);
+        done();
+      });
+    });
+  });
+
   context('regexp operator', function() {
     beforeEach(function deleteExistingTestFixtures(done) {
       Post.destroyAll(done);


### PR DESCRIPTION
### Description
Add order by rand () for mssql connector.
tests couldn't be unified in juggler since they are code specific and they work only for 4 connectors. 

#### Related issues

connect to https://github.com/strongloop/loopback/issues/902
To test feature in pr: https://github.com/strongloop/loopback-connector/pull/102
Original PR that cannot be used since the function is completely refactored
https://github.com/strongloop/loopback-connector-mysql/pull/62

### Checklist


- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

