### PR TITLE
Add 'ORDER BY' clause before 'OFFSET FETCH' clauses.

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -446,10 +446,13 @@ MsSQL.prototype.buildSelect = function(model, filter, options) {
     }
 
     if (filter.limit || filter.skip || filter.offset) {
+      if (filter.order && this.settings.supportsOffsetFetch) {
+        selectStmt.merge(this.buildOrderBy(model, filter.order));
+      }
       selectStmt = this.applyPagination(
         model, selectStmt, filter);
     } else {
-      if (filter.order) {
+      if (filter.order && !this.settings.supportsOffsetFetch) {
         selectStmt.merge(this.buildOrderBy(model, filter.order));
       }
     }


### PR DESCRIPTION
### Description
This PR adds 'ORDER BY' clauses before 'OFFSET FETCH' clauses,
when there is an 'order' filter, and when the option 'supportsOffsetFetch' is true

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->
- #153 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
