### PR TITLE
Fix/index autoupdate

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -251,28 +251,39 @@ function mixinMigration(MsSQL) {
 
     // add single-column indexes
     propNames.forEach(function(propName) {
-      var i = m.properties[propName].index;
-      if (!i) {
-        return;
-      }
       var found = ai[propName] && ai[propName].info;
-      var columnName = self.columnEscaped(model, propName);
       if (!found) {
-        var type = '';
-        var kind = '';
+        var tblName = self.tableEscaped(model);
+        var i = m.properties[propName].index;
+        if (!i) {
+          return;
+        }
+        var type = 'ASC';
+        var kind = 'NONCLUSTERED';
+        var unique = false;
         if (i.type) {
-          type = 'USING ' + i.type;
+          type = i.type;
         }
         if (i.kind) {
-          // kind = i.kind;
+          kind = i.kind;
         }
-        if (kind && type) {
-          sql.push('CREATE ' + kind + ' INDEX ' + columnName +
-            'ON ' +  self.tableEscaped(model) + ' (' + columnName + ') ' + type);
-        } else {
-          sql.push('CREATE ' + kind + ' INDEX [' + propName + '] ON ' +  self.tableEscaped(model) +
-            type + ' ([' + propName + ']) ');
+        if (i.unique) {
+          unique = true;
         }
+        var name = propName + '_' + kind + '_' + type + '_idx';
+        if (i.name) {
+          name = i.name;
+        }
+        self._idxNames[model].push(name);
+        var cmd = 'CREATE ' + (unique ? 'UNIQUE ' : '') + kind + ' INDEX [' + name + '] ON ' +
+          tblName + MsSQL.newline;
+        cmd += '(' + MsSQL.newline;
+        cmd += '    [' + propName + '] ' + type;
+        cmd += MsSQL.newline + ') WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE = OFF,' +
+          ' SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ' +
+          'ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON);' +
+          MsSQL.newline;
+        sql.push(cmd);
       }
     });
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -39,30 +39,23 @@ function mixinMigration(MsSQL) {
   };
 
   MsSQL.prototype.showIndexes = function(model, cb) {
-    // TODO: [rfeng] Implement SHOW INDEXES
-    /*
-     var schema = "'" + this.schemaName(model) +"'";
-     var table = "'" + this.escapeName(this.table(model)) +"'";
-     var sql = "SELECT OBJECT_SCHEMA_NAME(T.[object_id],DB_ID()) AS [table_schema],"
-     + " T.[name] AS [table_name], I.[name] AS [index_name], AC.[name] AS [column_name],"
-     + " I.[type_desc], I.[is_unique], I.[data_space_id], I.[ignore_dup_key], I.[is_primary_key],"
-     + " I.[is_unique_constraint], I.[fill_factor], I.[is_padded], I.[is_disabled], I.[is_hypothetical],"
-     + " I.[allow_row_locks], I.[allow_page_locks], IC.[is_descending_key], IC.[is_included_column]"
-     + " FROM sys.[tables] AS T"
-     + " INNER JOIN sys.[indexes] I ON T.[object_id] = I.[object_id]"
-     + " INNER JOIN sys.[index_columns] IC ON I.[object_id] = IC.[object_id]"
-     + " INNER JOIN sys.[all_columns] AC ON T.[object_id] = AC.[object_id] AND IC.[column_id] = AC.[column_id]"
-     + " WHERE T.[is_ms_shipped] = 0 AND I.[type_desc] <> 'HEAP'"
-     + " AND OBJECT_SCHEMA_NAME(T.[object_id],DB_ID()) = " + schema + " AND T.[name] = " + table
-     + " ORDER BY T.[name], I.[index_id], IC.[key_ordinal]";
+    var schema = "'" + this.schema(model) + "'";
+    var table = "'" + this.table(model) + "'";
+    var sql = 'SELECT OBJECT_SCHEMA_NAME(T.[object_id],DB_ID()) AS [table_schema],' +
+    ' T.[name] AS [table_name], I.[name] AS [index_name], AC.[name] AS [column_name],' +
+    ' I.[type_desc], I.[is_unique], I.[data_space_id], I.[ignore_dup_key], I.[is_primary_key],' +
+    ' I.[is_unique_constraint], I.[fill_factor], I.[is_padded], I.[is_disabled], I.[is_hypothetical],' +
+    ' I.[allow_row_locks], I.[allow_page_locks], IC.[is_descending_key], IC.[is_included_column]' +
+    ' FROM sys.[tables] AS T' +
+    ' INNER JOIN sys.[indexes] I ON T.[object_id] = I.[object_id]' +
+    ' INNER JOIN sys.[index_columns] IC ON I.[object_id] = IC.[object_id]' +
+    ' INNER JOIN sys.[all_columns] AC ON T.[object_id] = AC.[object_id] AND IC.[column_id] = AC.[column_id]' +
+    ' WHERE T.[is_ms_shipped] = 0 AND I.[type_desc] <> \'HEAP\'' +
+    ' AND OBJECT_SCHEMA_NAME(T.[object_id],DB_ID()) = ' + schema + ' AND T.[name] = ' + table +
+    ' ORDER BY T.[name], I.[index_id], IC.[key_ordinal]';
 
-     this.execute(sql, function (err, fields) {
-     cb && cb(err, fields);
-     });
-     */
-
-    process.nextTick(function() {
-      cb && cb(null, []);
+    this.execute(sql, function(err, fields) {
+      cb && cb(err, fields);
     });
   };
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -278,24 +278,45 @@ function mixinMigration(MsSQL) {
 
     // add multi-column indexes
     indexNames.forEach(function(indexName) {
-      var i = m.settings.indexes[indexName];
       var found = ai[indexName] && ai[indexName].info;
       if (!found) {
-        var type = '';
-        var kind = '';
+        var tblName = self.tableEscaped(model);
+        var i = m.settings.indexes[indexName];
+        var type = 'ASC';
+        var kind = 'NONCLUSTERED';
+        var unique = false;
         if (i.type) {
-          type = 'USING ' + i.type;
+          type = i.type;
         }
         if (i.kind) {
           kind = i.kind;
         }
-        if (kind && type) {
-          sql.push('CREATE ' + kind.toUpperCase() + ' INDEX [' + indexName + '] ON ' +  self.tableEscaped(model) + ' (' +
-            i.columns + ') ' + type);
-        } else {
-          sql.push('CREATE ' + kind.toUpperCase() + ' INDEX [' + indexName + '] ON ' +  self.tableEscaped(model) + ' (' +
-            i.columns + ') ');
+        if (i.unique) {
+          unique = true;
         }
+        var splitcolumns = i.columns.split(',');
+        var columns = [];
+        var name = '';
+
+        splitcolumns.forEach(function(elem, ind) {
+          var trimmed = elem.trim();
+          name += trimmed + '_';
+          trimmed = '[' + trimmed + '] ' + type;
+          columns.push(trimmed);
+        });
+
+        name += kind + '_' + type + '_idx';
+        self._idxNames[model].push(name);
+
+        var cmd = 'CREATE ' + (unique ? 'UNIQUE ' : '') + kind + ' INDEX [' + name + '] ON ' +
+          tblName + MsSQL.newline;
+        cmd += '(' + MsSQL.newline;
+        cmd += columns.join(',' + MsSQL.newline);
+        cmd += MsSQL.newline + ') WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE = OFF, ' +
+          'SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ' +
+          'ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON);' +
+          MsSQL.newline;
+        sql.push(cmd);
       }
     });
     return sql;

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -243,7 +243,7 @@ function mixinMigration(MsSQL) {
           });
         }
         if (!orderMatched) {
-          sql.push('DROP INDEX [' + self.columnEscaped(model, indexName) + ']');
+          sql.push('DROP INDEX ' + self.columnEscaped(model, indexName) + ' ON ' + self.tableEscaped(model));
           delete ai[indexName];
         }
       }
@@ -267,10 +267,10 @@ function mixinMigration(MsSQL) {
           // kind = i.kind;
         }
         if (kind && type) {
-          sql.push('ADD ' + kind + ' INDEX ' + columnName +
-            ' (' + columnName + ') ' + type);
+          sql.push('CREATE ' + kind + ' INDEX ' + columnName +
+            'ON ' +  self.tableEscaped(model) + ' (' + columnName + ') ' + type);
         } else {
-          sql.push('ADD ' + kind + ' INDEX [' + propName + '] ' +
+          sql.push('CREATE ' + kind + ' INDEX [' + propName + '] ON ' +  self.tableEscaped(model) +
             type + ' ([' + propName + ']) ');
         }
       }
@@ -290,10 +290,10 @@ function mixinMigration(MsSQL) {
           kind = i.kind;
         }
         if (kind && type) {
-          sql.push('ADD ' + kind + ' INDEX [' + indexName + '] (' +
+          sql.push('CREATE ' + kind.toUpperCase() + ' INDEX [' + indexName + '] ON ' +  self.tableEscaped(model) + ' (' +
             i.columns + ') ' + type);
         } else {
-          sql.push('ADD ' + kind + ' INDEX [' + indexName + '] (' +
+          sql.push('CREATE ' + kind.toUpperCase() + ' INDEX [' + indexName + '] ON ' +  self.tableEscaped(model) + ' (' +
             i.columns + ') ');
         }
       }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -221,7 +221,7 @@ function mixinMigration(MsSQL) {
 
     // remove indexes
     aiNames.forEach(function(indexName) {
-      if (ai[indexName].info.Column_name === idName || indexName.substr(0, 3) === 'PK_') {
+      if (indexName.substr(0, 3) === 'PK_') {
         return;
       }
       if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -42,7 +42,7 @@ function mixinMigration(MsSQL) {
     var schema = "'" + this.schema(model) + "'";
     var table = "'" + this.table(model) + "'";
     var sql = 'SELECT OBJECT_SCHEMA_NAME(T.[object_id],DB_ID()) AS [table_schema],' +
-    ' T.[name] AS [table_name], I.[name] AS [index_name], AC.[name] AS [column_name],' +
+    ' T.[name] AS [Table], I.[name] AS [Key_name], AC.[name] AS [Column_name],' +
     ' I.[type_desc], I.[is_unique], I.[data_space_id], I.[ignore_dup_key], I.[is_primary_key],' +
     ' I.[is_unique_constraint], I.[fill_factor], I.[is_padded], I.[is_disabled], I.[is_hypothetical],' +
     ' I.[allow_row_locks], I.[allow_page_locks], IC.[is_descending_key], IC.[is_included_column]' +
@@ -221,12 +221,12 @@ function mixinMigration(MsSQL) {
 
     // remove indexes
     aiNames.forEach(function(indexName) {
-      if (indexName === idName || indexName === 'PRIMARY') {
+      if (ai[indexName].info.Column_name === idName || indexName.substr(0, 3) === 'PK_') {
         return;
       }
       if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||
         m.properties[indexName] && !m.properties[indexName].index) {
-        sql.push('DROP INDEX ' + self.columnEscaped(model, indexName));
+        sql.push('DROP INDEX ' + indexName + ' ON ' + self.tableEscaped(model));
       } else {
         // first: check single (only type and kind)
         if (m.properties[indexName] && !m.properties[indexName].index) {

--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -407,7 +407,8 @@ MsSQL.prototype.tableEscaped = function(model) {
 MsSQL.prototype.applySqlChanges = function(model, pendingChanges, cb) {
   var self = this;
   if (pendingChanges.length) {
-    var thisQuery = pendingChanges[0].substring(0, 10) !== 'DROP INDEX' ? 'ALTER TABLE ' + self.tableEscaped(model)  : '';
+    var alterTable = (pendingChanges[0].substring(0, 10) !== 'DROP' && pendingChanges[0].substring(0, 6) !== 'CREATE');
+    var thisQuery = alterTable ? 'ALTER TABLE ' + self.tableEscaped(model)  : '';
     var ranOnce = false;
     pendingChanges.forEach(function(change) {
       if (ranOnce) {

--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -404,6 +404,22 @@ MsSQL.prototype.tableEscaped = function(model) {
     this.escapeName(this.table(model));
 };
 
+MsSQL.prototype.applySqlChanges = function(model, pendingChanges, cb) {
+  var self = this;
+  if (pendingChanges.length) {
+    var thisQuery = pendingChanges[0].substring(0, 10) !== 'DROP INDEX' ? 'ALTER TABLE ' + self.tableEscaped(model)  : '';
+    var ranOnce = false;
+    pendingChanges.forEach(function(change) {
+      if (ranOnce) {
+        thisQuery = thisQuery + ' ';
+      }
+      thisQuery = thisQuery + ' ' + change;
+      ranOnce = true;
+    });
+    self.execute(thisQuery, cb);
+  }
+};
+
 function buildLimit(limit, offset) {
   if (isNaN(offset)) {
     offset = 0;

--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -407,7 +407,7 @@ MsSQL.prototype.tableEscaped = function(model) {
 MsSQL.prototype.applySqlChanges = function(model, pendingChanges, cb) {
   var self = this;
   if (pendingChanges.length) {
-    var alterTable = (pendingChanges[0].substring(0, 10) !== 'DROP' && pendingChanges[0].substring(0, 6) !== 'CREATE');
+    var alterTable = (pendingChanges[0].substring(0, 10) !== 'DROP INDEX' && pendingChanges[0].substring(0, 6) !== 'CREATE');
     var thisQuery = alterTable ? 'ALTER TABLE ' + self.tableEscaped(model)  : '';
     var ranOnce = false;
     pendingChanges.forEach(function(change) {

--- a/test/autoupdate.test.js
+++ b/test/autoupdate.test.js
@@ -27,6 +27,19 @@ describe('MS SQL server connector', function() {
             schema: 'dbo',
             table: 'CUSTOMER_TEST',
           },
+          indexes: {
+            idEmailIndex: {
+              keys: {
+                id: 1,
+                email: 1,
+              },
+              options: {
+                unique: true,
+              },
+              columns: 'id,email',
+              kind: 'unique',
+            },
+          },
         },
         properties: {
           id: {
@@ -61,15 +74,15 @@ describe('MS SQL server connector', function() {
             table: 'CUSTOMER_TEST',
           },
           indexes: {
-            idEmailIndex: {
+            idCityIndex: {
               keys: {
                 id: 1,
-                email: 1,
+                city: 1,
               },
               options: {
                 unique: true,
               },
-              columns: 'id,email',
+              columns: 'id,city',
               kind: 'unique',
             },
           },
@@ -97,6 +110,11 @@ describe('MS SQL server connector', function() {
             length: 40,
           },
           lastName: {
+            type: 'String',
+            required: false,
+            length: 40,
+          },
+          city: {
             type: 'String',
             required: false,
             length: 40,
@@ -129,7 +147,7 @@ describe('MS SQL server connector', function() {
         /* eslint-enable camelcase */
         ds.autoupdate(function(err, result) {
           ds.discoverModelProperties('CUSTOMER_TEST', function(err, props) {
-            assert.equal(props.length, 4);
+            assert.equal(props.length, 5);
             var names = props.map(function(p) {
               return p.columnName;
             });
@@ -137,6 +155,7 @@ describe('MS SQL server connector', function() {
             assert.equal(names[1], 'email');
             assert.equal(names[2], 'firstName');
             assert.equal(names[3], 'lastName');
+            assert.equal(names[4], 'city');
 
             var schema = "'dbo'";
             var table = "'CUSTOMER_TEST'";
@@ -154,13 +173,18 @@ describe('MS SQL server connector', function() {
             ' ORDER BY T.[name], I.[index_id], IC.[key_ordinal]';
 
             ds.connector.execute(sql, function(err, indexes) {
-              var count = 0;
+              var countIdEmailIndex = 0;
+              var countIdCityIndex = 0;
               for (var i = 0; i < indexes.length; i++) {
-                if (indexes[i].Key_name == 'idEmailIndex') {
-                  count++;
+                if (indexes[i].Key_name == 'id_email_unique_ASC_idx') {
+                  countIdEmailIndex++;
+                }
+                if (indexes[i].Key_name == 'id_city_unique_ASC_idx') {
+                  countIdCityIndex++;
                 }
               }
-              assert.equal(count, 3);
+              assert.equal(countIdEmailIndex, 0);
+              assert.equal(countIdCityIndex, 3);
               done(err, result);
             });
           });

--- a/test/autoupdate.test.js
+++ b/test/autoupdate.test.js
@@ -182,6 +182,8 @@ describe('MS SQL server connector', function() {
             ds.connector.execute(sql, function(err, indexes) {
               var countIdEmailIndex = 0;
               var countIdCityIndex = 0;
+              var countCityIndex = 0;
+              var countAgeIndex = 0;
               for (var i = 0; i < indexes.length; i++) {
                 if (indexes[i].Key_name == 'id_email_unique_ASC_idx') {
                   countIdEmailIndex++;
@@ -189,9 +191,17 @@ describe('MS SQL server connector', function() {
                 if (indexes[i].Key_name == 'id_city_unique_ASC_idx') {
                   countIdCityIndex++;
                 }
+                if (indexes[i].Key_name == 'city_NONCLUSTERED_ASC_idx') {
+                  countCityIndex++;
+                }
+                if (indexes[i].Key_name == 'age_NONCLUSTERED_ASC_idx') {
+                  countAgeIndex++;
+                }
               }
               assert.equal(countIdEmailIndex, 0);
+              assert.equal(countAgeIndex, 0);
               assert.equal(countIdCityIndex > 0, true);
+              assert.equal(countCityIndex > 0, true);
               done(err, result);
             });
           });

--- a/test/autoupdate.test.js
+++ b/test/autoupdate.test.js
@@ -61,6 +61,10 @@ describe('MS SQL server connector', function() {
             type: 'Number',
             required: false,
           },
+          firstName: {
+            type: 'String',
+            required: false,
+          },
         },
       };
 
@@ -118,6 +122,9 @@ describe('MS SQL server connector', function() {
             type: 'String',
             required: false,
             length: 40,
+            index: {
+              unique: true,
+            },
           },
         },
       };
@@ -129,7 +136,7 @@ describe('MS SQL server connector', function() {
       assert(!err);
       ds.discoverModelProperties('CUSTOMER_TEST', function(err, props) {
         assert(!err);
-        assert.equal(props.length, 4);
+        assert.equal(props.length, 5);
         var names = props.map(function(p) {
           return p.columnName;
         });
@@ -184,7 +191,7 @@ describe('MS SQL server connector', function() {
                 }
               }
               assert.equal(countIdEmailIndex, 0);
-              assert.equal(countIdCityIndex, 3);
+              assert.equal(countIdCityIndex > 0, true);
               done(err, result);
             });
           });


### PR DESCRIPTION
### Description
This pull request resolves #121.

In order to achieve this, I used the commented showIndexes and modified it a little bit to get the current indices.

There were multiple MsSQL syntax errors in the modification of indices (but the disabled' showIndexes function resulted in passing unittest).

Syntax errors are resolved, and indices are now after an update also built according to the migrate functions. (Using DROP INDEX and CREATE INDEX instead of ALTER TABLE ADD/DROP)
The autoupdate test is extended with index checking. All tests are passing.

Please let me know what you think.

#### Related issues
- connect to #121 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
