### PR TITLE
Fix unnecessary removal of indices

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -189,6 +189,59 @@ function mixinMigration(MsSQL) {
     return statements;
   };
 
+  MsSQL.prototype.generatePropIndexName = function(propName, model) {
+    var i = model.properties[propName].index;
+    if (!i) {
+      return;
+    }
+    var type = 'ASC';
+    var kind = 'NONCLUSTERED';
+    var unique = false;
+    if (i.type) {
+      type = i.type;
+    }
+    if (i.kind) {
+      kind = i.kind;
+    }
+    if (i.unique) {
+      unique = true;
+    }
+    var name = propName + '_' + kind + '_' + type + '_idx';
+    if (i.name) {
+      name = i.name;
+    }
+    model.properties[propName].generatedPropIndexName = name;
+    return name;
+  };
+
+  MsSQL.prototype.generateIndexName = function(indexName, model) {
+    var i = model.settings.indexes[indexName];
+    var type = 'ASC';
+    var kind = 'NONCLUSTERED';
+    var unique = false;
+    if (i.type) {
+      type = i.type;
+    }
+    if (i.kind) {
+      kind = i.kind;
+    }
+    if (i.unique) {
+      unique = true;
+    }
+    var splitcolumns = i.columns.split(',');
+    var columns = [];
+    var name = '';
+    splitcolumns.forEach(function(elem, ind) {
+      var trimmed = elem.trim();
+      name += trimmed + '_';
+      trimmed = '[' + trimmed + '] ' + type;
+      columns.push(trimmed);
+    });
+    name += kind + '_' + type + '_idx';
+    model.settings.indexes[indexName].generatedIndexName = name;
+    return name;
+  };
+
   MsSQL.prototype.addIndexes = function(model, actualIndexes) {
     var self = this;
     var m = this._models[model];
@@ -197,8 +250,14 @@ function mixinMigration(MsSQL) {
     var indexNames = m.settings.indexes ? Object.keys(m.settings.indexes).filter(function(name) {
       return !!m.settings.indexes[name];
     }) : [];
+    var generatedIndexNames = indexNames.map(function(indexName) {
+      return self.generateIndexName(indexName, m);
+    });
     var propNames = Object.keys(m.properties).filter(function(name) {
       return !!m.properties[name];
+    });
+    var generatedPropIndexNames = propNames.map(function(propName) {
+      return self.generatePropIndexName(propName, m);
     });
 
     var ai = {};
@@ -224,34 +283,16 @@ function mixinMigration(MsSQL) {
       if (indexName.substr(0, 3) === 'PK_') {
         return;
       }
-      if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||
-        m.properties[indexName] && !m.properties[indexName].index) {
+      if (generatedIndexNames.indexOf(indexName) === -1 &&
+        generatedPropIndexNames.indexOf(indexName) === -1) {
         sql.push('DROP INDEX ' + indexName + ' ON ' + self.tableEscaped(model));
-      } else {
-        // first: check single (only type and kind)
-        if (m.properties[indexName] && !m.properties[indexName].index) {
-          // TODO
-          return;
-        }
-        // second: check multiple indexes
-        var orderMatched = true;
-        if (indexNames.indexOf(indexName) !== -1) {
-          m.settings.indexes[indexName].columns.split(/,\s*/).forEach(function(columnName, i) {
-            if (ai[indexName].columns[i] !== columnName) {
-              orderMatched = false;
-            }
-          });
-        }
-        if (!orderMatched) {
-          sql.push('DROP INDEX ' + self.columnEscaped(model, indexName) + ' ON ' + self.tableEscaped(model));
-          delete ai[indexName];
-        }
       }
     });
 
     // add single-column indexes
     propNames.forEach(function(propName) {
-      var found = ai[propName] && ai[propName].info;
+      var generatedIndexPropName = m.properties[propName].generatedPropIndexName;
+      var found = ai[generatedIndexPropName] && ai[generatedIndexPropName].info;
       if (!found) {
         var tblName = self.tableEscaped(model);
         var i = m.properties[propName].index;
@@ -270,10 +311,7 @@ function mixinMigration(MsSQL) {
         if (i.unique) {
           unique = true;
         }
-        var name = propName + '_' + kind + '_' + type + '_idx';
-        if (i.name) {
-          name = i.name;
-        }
+        var name = self.generatePropIndexName(propName, m);
         self._idxNames[model].push(name);
         var cmd = 'CREATE ' + (unique ? 'UNIQUE ' : '') + kind + ' INDEX [' + name + '] ON ' +
           tblName + MsSQL.newline;
@@ -289,7 +327,8 @@ function mixinMigration(MsSQL) {
 
     // add multi-column indexes
     indexNames.forEach(function(indexName) {
-      var found = ai[indexName] && ai[indexName].info;
+      var generatedIndexName = m.settings.indexes[indexName].generatedIndexName;
+      var found = ai[generatedIndexName] && ai[generatedIndexName].info;
       if (!found) {
         var tblName = self.tableEscaped(model);
         var i = m.settings.indexes[indexName];
@@ -307,7 +346,6 @@ function mixinMigration(MsSQL) {
         }
         var splitcolumns = i.columns.split(',');
         var columns = [];
-        var name = '';
 
         splitcolumns.forEach(function(elem, ind) {
           var trimmed = elem.trim();
@@ -315,8 +353,7 @@ function mixinMigration(MsSQL) {
           trimmed = '[' + trimmed + '] ' + type;
           columns.push(trimmed);
         });
-
-        name += kind + '_' + type + '_idx';
+        var name = self.generateIndexName(indexName, m);
         self._idxNames[model].push(name);
 
         var cmd = 'CREATE ' + (unique ? 'UNIQUE ' : '') + kind + ' INDEX [' + name + '] ON ' +
@@ -415,10 +452,7 @@ function mixinMigration(MsSQL) {
     if (i.unique) {
       unique = true;
     }
-    var name = prop + '_' + kind + '_' + type + '_idx';
-    if (i.name) {
-      name = i.name;
-    }
+    var name = this.generatePropIndexName(prop, this._models[model]);
     this._idxNames[model].push(name);
     var cmd = 'CREATE ' + (unique ? 'UNIQUE ' : '') + kind + ' INDEX [' + name + '] ON ' +
       tblName + MsSQL.newline;
@@ -449,15 +483,13 @@ function mixinMigration(MsSQL) {
     }
     var splitcolumns = i.columns.split(',');
     var columns = [];
-    var name = '';
     splitcolumns.forEach(function(elem, ind) {
       var trimmed = elem.trim();
       name += trimmed + '_';
       trimmed = '[' + trimmed + '] ' + type;
       columns.push(trimmed);
     });
-
-    name += kind + '_' + type + '_idx';
+    var name = this.generateIndexName(prop, this._models[model]);
     this._idxNames[model].push(name);
 
     var cmd = 'CREATE ' + (unique ? 'UNIQUE ' : '') + kind + ' INDEX [' + name + '] ON ' +


### PR DESCRIPTION
### Description

Addition to #174 
The existing indices function checked if there was an index with the indexName available in the database.
However, the name of the index in the database is generated according to the columns and properties (e.g. `id_NONCLUSTERED_ASC_idx`), which is not the same as the name in the model.json.
This resulted in unnecessary removal and creation of indexes (which resulted in concurrency issues in my project).

In order to fix this, the naming of the property indices and custom indices is centralized in `MsSQL.prototype.generatePropIndexName()` and `MsSQL.prototype.generateIndexName()`.
Indices are only removed, if the index is not present in `generatedPropIndexNames` and `generatedIndexNames`


#### Related issues

- connect to #174  

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
