### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,8 @@
 # Each line is a file pattern followed by one or more owners,
 # the last matching pattern has the most precendence.
 
+# Alumni members
+# @kjdelisle @loay @ssh24 
+
 # Core team members from IBM
-* @kjdelisle @jannyHou @loay @b-admike @ssh24 @virkt25 @dhmlau
+* @jannyHou @b-admike @virkt25 @dhmlau


### PR DESCRIPTION
### Description
To add the previous maintainers as "alumni members" in the comment.
