### PR TITLE
Increase test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "lint": "eslint .",
     "pretest": "node pretest.js",
-    "test": "./node_modules/.bin/mocha --timeout 9999 --require test/init.js -R spec",
+    "test": "mocha",
     "posttest": "npm run lint",
     "prepublish": "node remove-regenerator.js"
   },

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--timeout 9999
+--require test/init.js
+--reporter spec

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
---timeout 9999
+--timeout 30000
 --require test/init.js
 --reporter spec


### PR DESCRIPTION
Looks like the test timeout of ~10 seconds is not enough when running on our CI, see e.g. [build #198](https://cis-jenkins.swg-devops.com/job/ds/job/loopback-connector-mssql%7Emaster/198/) (accessible from internal IBM network only, sorry).

This patch moves Mocha configuration to `test/mocha.opts` and increases the test timeout to 30 seconds per test.