### PR TITLE
update to MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,25 @@
-Licensed Materials - Property of IBM
-IBM StrongLoop Software
-Copyright IBM Corp. 2016. All Rights Reserved.
-US Government Users Restricted Rights - Use, duplication or disclosure
-restricted by GSA ADP Schedule Contract with IBM Corp.
+Copyright (c) IBM Corp. 2012,2018. All Rights Reserved.
+Node module: loopback-connector-mssql
+This project is licensed under the MIT License, full text below.
 
-See full text of IBM International Program License Agreement (IPLA)
-http://www-03.ibm.com/software/sla/sladb.nsf/pdf/ipla/$file/ipla.pdf
+--------
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var SG = require('strong-globalize');

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var g = require('strong-globalize')();

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var g = require('strong-globalize')();

--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var g = require('strong-globalize')();

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var debug = require('debug')('loopback:connector:mssql:transaction');

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-connector-mssql.git"
   },
-  "license": "SEE LICENSE IN LICENSE.md"
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT"
 }

--- a/pretest.js
+++ b/pretest.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-connector-mssql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 'use strict';
 
 require('./test/init');

--- a/remove-regenerator.js
+++ b/remove-regenerator.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 /**
  * This script removes regenerator bundled with babel-runtime

--- a/test/autoupdate.test.js
+++ b/test/autoupdate.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 require('./init.js');

--- a/test/commontests.js
+++ b/test/commontests.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var jdb = require('loopback-datasource-juggler');

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 /* eslint-env node, mocha */
 'use strict';

--- a/test/discover.test.js
+++ b/test/discover.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 process.env.NODE_ENV = 'test';

--- a/test/id.test.js
+++ b/test/id.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 require('./init.js');

--- a/test/imported.test.js
+++ b/test/imported.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 describe('mssql imported features', function() {

--- a/test/init.js
+++ b/test/init.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 module.exports = require('should');

--- a/test/mapping.test.js
+++ b/test/mapping.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 var should = require('should');

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 require('./init');

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-mssql
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 require('./init.js');


### PR DESCRIPTION
### Description
To help to continue growing the community, we decided to change the license of this module to MIT license. 

The license used here is using https://github.com/strongloop/loopback-connector-mysql/blob/master/LICENSE as reference.

Changes involved in this PR:

- update `LICENSE.md` to MIT license
- update `license` and `copyright.owner` field, in package.json
- run `slt copyright` to update the copyright statement in the header of source code files.