### PR TITLE
#191 AutoUpdate needs to have order when executing index related operation…

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -202,7 +202,8 @@ function mixinMigration(MsSQL) {
     });
 
     var ai = {};
-    var sql = [];
+    var sqlAdd = [];
+    var sqlDrop = [];
 
     if (actualIndexes) {
       actualIndexes.forEach(function(i) {
@@ -226,7 +227,7 @@ function mixinMigration(MsSQL) {
       }
       if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||
         m.properties[indexName] && !m.properties[indexName].index) {
-        sql.push('DROP INDEX ' + indexName + ' ON ' + self.tableEscaped(model));
+        sqlDrop.push('DROP INDEX ' + indexName + ' ON ' + self.tableEscaped(model));
       } else {
         // first: check single (only type and kind)
         if (m.properties[indexName] && !m.properties[indexName].index) {
@@ -243,7 +244,7 @@ function mixinMigration(MsSQL) {
           });
         }
         if (!orderMatched) {
-          sql.push('DROP INDEX ' + self.columnEscaped(model, indexName) + ' ON ' + self.tableEscaped(model));
+          sqlDrop.push('DROP INDEX ' + self.columnEscaped(model, indexName) + ' ON ' + self.tableEscaped(model));
           delete ai[indexName];
         }
       }
@@ -283,7 +284,7 @@ function mixinMigration(MsSQL) {
           ' SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ' +
           'ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON);' +
           MsSQL.newline;
-        sql.push(cmd);
+        sqlAdd.push(cmd);
       }
     });
 
@@ -327,10 +328,13 @@ function mixinMigration(MsSQL) {
           'SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ' +
           'ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON);' +
           MsSQL.newline;
-        sql.push(cmd);
+        sqlDrop.push(cmd);
       }
     });
-    return sql;
+    return {
+      drop: sqlDrop,
+      add: sqlAdd,
+    };
   };
 
   MsSQL.prototype.alterTable = function(model, actualFields, actualIndexes, done, checkOnly) {
@@ -338,7 +342,8 @@ function mixinMigration(MsSQL) {
 
     var statements = self.getAddModifyColumns(model, actualFields);
     statements = statements.concat(self.getDropColumns(model, actualFields));
-    statements = statements.concat(self.addIndexes(model, actualIndexes));
+    var indexStatements = self.addIndexes(model, actualIndexes);
+    statements = statements.concat(indexStatements.drop);
 
     async.each(statements, function(query, fn) {
       if (checkOnly) {
@@ -347,7 +352,18 @@ function mixinMigration(MsSQL) {
         self.applySqlChanges(model, [query], fn);
       }
     }, function(err, results) {
-      done && done(err, results);
+      if (err) {
+        return done && done(err, results);
+      }
+      async.each(indexStatements.add, function(query, fn) {
+        if (checkOnly) {
+          fn(null, true, {statements: statements, query: query});
+        } else {
+          self.applySqlChanges(model, [query], fn);
+        }
+      }, function(err, results) {
+        done && done(err, results);
+      });
     });
   };
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -328,7 +328,7 @@ function mixinMigration(MsSQL) {
           'SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ' +
           'ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON);' +
           MsSQL.newline;
-        sqlDrop.push(cmd);
+        sqlAdd.push(cmd);
       }
     });
     return {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -371,13 +371,15 @@ function mixinMigration(MsSQL) {
     // debugger;
     var self = this;
     var objModel = this._models[model];
-    var modelPKID = this.idName(model);
+    var modelPKIDs = this.idNames(model) || [];
 
     var sql = [];
     var props = Object.keys(objModel.properties);
     for (var i = 0, n = props.length; i < n; i++) {
       var prop = props[i];
-      if (prop === modelPKID) {
+      var pkidIndex = modelPKIDs.indexOf(prop);
+      if (pkidIndex > -1) {
+        var modelPKID = modelPKIDs[pkidIndex];
         var idProp = objModel.properties[modelPKID];
         if (idProp.type === Number) {
           if (idProp.generated !== false) {
@@ -403,11 +405,15 @@ function mixinMigration(MsSQL) {
     }
     var joinedSql = sql.join(',' + MsSQL.newline + '    ');
     var cmd = '';
-    if (modelPKID) {
+    if (modelPKIDs.length > 0) {
+      var columns = [];
+      modelPKIDs.forEach(function(modelPKID) {
+        columns.push(' ' + self.columnEscaped(model, modelPKID) + ' ASC');
+      });
       cmd = 'PRIMARY KEY CLUSTERED' + MsSQL.newline + '(' + MsSQL.newline;
-      cmd += ' ' + self.columnEscaped(model, modelPKID) + ' ASC' + MsSQL.newline;
-      cmd += ') WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, ' +
-      'IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON)';
+      cmd += columns.join(',' + MsSQL.newline);
+      cmd += MsSQL.newline + ') WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, ' +
+        'IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON)';
     }
 
     joinedSql += ',' + MsSQL.newline + cmd;

--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -12,7 +12,11 @@ var SqlConnector = require('loopback-connector').SqlConnector;
 var ParameterizedSQL = SqlConnector.ParameterizedSQL;
 var util = require('util');
 var debug = require('debug')('loopback:connector:mssql');
-
+var LoopBackContext;
+try{
+  LoopBackContext = require('loopback-context');
+} catch(err){
+}
 mssql.map.register(Number, mssql.BigInt);
 
 var name = 'mssql';
@@ -78,6 +82,27 @@ function format(sql, params) {
   return sql;
 }
 
+MsSQL.prototype.execute = function(sql, params, options, callback) {
+  const lbc = LoopBackContext && LoopBackContext.getCurrentContext && LoopBackContext.getCurrentContext();
+  if (typeof params === 'function' && options === undefined &&
+    callback === undefined) {
+    // execute(sql, callback)
+    options = {};
+    callback = params;
+    params = [];
+  } else if (typeof options === 'function' && callback === undefined) {
+    // execute(sql, params, callback)
+    callback = options;
+    options = {};
+  }
+  params = params || [];
+  options = options || {};
+  if (typeof callback === 'function' && lbc && lbc.bind) {
+    callback = lbc.bind(callback);
+  }
+  return SqlConnector.prototype.execute.call(this, sql, params, options, callback);
+};
+
 MsSQL.prototype.connect = function(callback) {
   var self = this;
   if (self.client) {
@@ -89,6 +114,9 @@ MsSQL.prototype.connect = function(callback) {
       return callback(err);
     }
     debug('Connection established: ', self.settings.server);
+    connection.on('error', err => {
+      debug('error: %j', err);
+    });
     self.client = connection;
     callback(err, connection);
   });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "async": "^2.6.1",
     "debug": "^3.1.0",
     "loopback-connector": "^4.5.0",
-    "mssql": "^4.1.0",
+    "mssql": "^4.2.3",
     "strong-globalize": "^4.1.1",
     "sqlcmdjs": "^1.5.0"
   },


### PR DESCRIPTION
# Description/Steps to reproduce

Auto update generates ordered statements on indexes, so that it will drop the existing index and recreate it.
Because of the async execution of all the statements, the add index can run before the drop index which causes the update to fail.

# Expected result

index related operations while updating should be done in a dependent matter and only after all coulmns were updated. The best approach will be to do the following:
1. run async all columns related statements and all drop indexes related statements
2. run async all create indexes related statments
