### PR TITLE
Fix applyPagination when supportsOffsetFetch is true (#195)

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -485,9 +485,10 @@ MsSQL.prototype.buildSelect = function(model, filter, options) {
 MsSQL.prototype.applyPagination =
   function(model, stmt, filter) {
     var offset = filter.offset || filter.skip || 0;
-    if (this.settings.supportsOffsetFetch) {
+    if (this.settings.supportsOffsetFetch && filter.order) {
       // SQL 2012 or later
       // http://technet.microsoft.com/en-us/library/gg699618.aspx
+      stmt.merge(this.buildOrderBy(model, filter.order));
       var limitClause = buildLimit(filter.limit, filter.offset || filter.skip);
       return stmt.merge(limitClause);
     } else {


### PR DESCRIPTION
### Description
The existing function applyPagination generated an OFFSET-FETCH clause which resulted into `Invalid usage of the option NEXT in the FETCH statement` when `settings.supportsOffsetFetch` was true, due to missing ORDER BY clause (https://technet.microsoft.com/en-us/library/gg699618.aspx).

Now applyPagination checks for filter.order before creating an OFFSET-FETCH clause, and if it exists, adds the ORDER BY clause.

#### Related issues

- connect to #195

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
