### PR TITLE
update mssql to 5.x and sqlcmdjs is a devDependency

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -205,7 +205,7 @@ MsSQL.prototype.buildInsertInto = function(model, fields, options) {
     stmt.merge(
       'OUTPUT INSERTED.' +
       this.columnEscaped(model, idName) +
-      ' into @insertedIds'
+      ' into @insertedIds',
     );
   }
   return stmt;
@@ -472,7 +472,7 @@ MsSQL.prototype.buildSelect = function(model, filter, options) {
 
     if (filter.limit || filter.skip || filter.offset) {
       selectStmt = this.applyPagination(
-        model, selectStmt, filter
+        model, selectStmt, filter,
       );
     } else {
       if (filter.order) {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,8 @@
     "async": "^3.1.0",
     "debug": "^4.1.1",
     "loopback-connector": "^4.8.0",
-    "mssql": "^4.1.0",
-    "strong-globalize": "^5.0.0",
-    "sqlcmdjs": "^1.5.0"
+    "mssql": "^5.1.0",
+    "strong-globalize": "^5.0.0"
   },
   "bundledDependencies": [
     "mssql"
@@ -36,7 +35,8 @@
     "mocha": "^6.1.4",
     "rc": "^1.2.8",
     "should": "^13.2.3",
-    "sinon": "^6.1.3"
+    "sinon": "^6.1.3",
+    "sqlcmdjs": "^1.5.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/remove-regenerator.js
+++ b/remove-regenerator.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 try {
   const index = require.resolve('babel-runtime/regenerator/index.js');
   const runtime = require.resolve(
-    'babel-runtime/regenerator/runtime.js'
+    'babel-runtime/regenerator/runtime.js',
   );
   if (index) {
     fs.unlink(index, function(err) {

--- a/test/init.js
+++ b/test/init.js
@@ -42,6 +42,10 @@ global.getConfig = function(options) {
     }
   }
 
+  if (typeof dbConf.port === 'string') {
+    dbConf.port = parseInt(dbConf.port);
+  }
+
   return dbConf;
 };
 

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -172,7 +172,7 @@ describe('mssql connector', function() {
                 if (err) return done(err);
                 data.should.be.eql(
                   [{V1: '(?)',
-                    V2: ', 1 ); INSERT INTO SQLI_TEST VALUES (1, 2); --'}]
+                    V2: ', 1 ); INSERT INTO SQLI_TEST VALUES (1, 2); --'}],
                 );
                 done();
               });
@@ -238,7 +238,7 @@ describe('mssql connector', function() {
           p.should.have.property('rating', 3.5);
           done();
         });
-      }
+      },
     );
   });
 
@@ -291,7 +291,7 @@ describe('mssql connector', function() {
             console.warn.calledOnce.should.be.ok;
             should.exist(err);
             done();
-          }
+          },
         );
       });
     });


### PR DESCRIPTION
### Description
This PR updates the mssql-driver to 5.x (preventing some depreciation errors from the underlying tedious library) and marks sqlcmdjs as a dev dependency as it is only used for testing. All tests are passing on my local development machine.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #184

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
