### PR TITLE
fix: added missing 'ORDER BY' before 'OFFSET'

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -426,7 +426,7 @@ function buildLimit(limit, offset) {
   if (isNaN(offset)) {
     offset = 0;
   }
-  let sql = 'OFFSET ' + offset + ' ROWS';
+  let sql = 'ORDER BY RowNum OFFSET ' + offset + ' ROWS';
   if (limit >= 0) {
     sql += ' FETCH NEXT ' + limit + ' ROWS ONLY';
   }


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

Related: strongloop/loopback-next#4160

If the `supportsOffsetFetch` is enabled, the generated SQL query is invalid as it does not comply with the expected syntax of a [SELECT - ORDER BY Clause](https://docs.microsoft.com/en-us/sql/t-sql/queries/select-order-by-clause-transact-sql?view=sql-server-ver15).

This PR resolves this issue by prepending the missing `ORDER BY` to `OFFSET`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mssql) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
