### PR TITLE
fix: added missing 'ORDER BY' before 'OFFSET' II

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -426,7 +426,7 @@ function buildLimit(limit, offset) {
   if (isNaN(offset)) {
     offset = 0;
   }
-  let sql = 'OFFSET ' + offset + ' ROWS';
+  let sql = 'ORDER BY RowNum OFFSET ' + offset + ' ROWS';
   if (limit >= 0) {
     sql += ' FETCH NEXT ' + limit + ' ROWS ONLY';
   }

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -7,12 +7,21 @@
 require('./init');
 
 const should = require('should');
-let Post, PostWithUUID, PostWithStringId, db;
+let User, Post, PostWithUUID, PostWithStringId, db, dbOSF;
 
 describe('mssql connector', function() {
   before(function() {
     /* global getDataSource */
     db = getDataSource();
+    dbOSF = getDataSource({
+      supportsOffSetFetch: true,
+    });
+
+    User = dbOSF.define('User', {
+      id: {type: Number, generated: true, id: true},
+      name: String,
+      age: Number,
+    });
 
     Post = db.define('PostWithBoolean', {
       title: {type: String, length: 255, index: true},
@@ -240,6 +249,28 @@ describe('mssql connector', function() {
         });
       },
     );
+  });
+
+  it('should support limit', function(done) {
+    Post.find({
+      limit: 3,
+    }, (err, result) => {
+      should.not.exist(err);
+      should.exist(result);
+      result.should.have.length(3);
+      done();
+    });
+  });
+
+  it('should support limit with \'supportsOffsetFetch\'', function(done) {
+    User.find({
+      limit: 3,
+    }, (err, result) => {
+      should.not.exist(err);
+      should.exist(result);
+      result.should.have.length(3);
+      done();
+    });
   });
 
   context('regexp operator', function() {


### PR DESCRIPTION
If the supportsOffsetFetch is enabled, the generated SQL query is invalid as it does not comply with the expected syntax of a SELECT - ORDER BY Clause.

This PR resolves this issue by prepending the missing ORDER BY to OFFSET.

_This PR was originally created by @achrinza_

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mssql) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
