### PR TITLE
Remove node_modules from tarballs published to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ logs
 results
 
 *.sublime*
-node_modules/
+node_modules
 db/
 
 npm-debug.log


### PR DESCRIPTION
Apparently `npm` does not understand `.gitignore` syntax `node_modules/`. As a result, when our `slt-release` tool creates `.npmignore` file from `.gitignore` file, we end up with rules that don't exclude `deps/juggler-v{3,4}/node_modules` and those node modules are included in the package. Installing such package on Windows fails with EPERM errors.

This patch fixes https://github.com/strongloop/loopback-connector-mssql/issues/223

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mssql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
