### PR TITLE
Execute alterTable statements in order

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -340,7 +340,7 @@ function mixinMigration(MsSQL) {
     statements = statements.concat(self.getDropColumns(model, actualFields));
     statements = statements.concat(self.addIndexes(model, actualIndexes));
 
-    async.each(statements, function(query, fn) {
+    async.eachSeries(statements, function(query, fn) {
       if (checkOnly) {
         fn(null, true, {statements: statements, query: query});
       } else {


### PR DESCRIPTION
async.each() in alterTable executes the statements in parallel, allowing for things like creating an index before dropping it. Change async.each to async.eachSeries in order to execute the statements in proper order.

Fixes #180 