### PR TITLE
chore: drop node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.8.0",
   "description": "Microsoft SQL Server connector for LoopBack",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
Node 8 has reached end of life. This PR drops support for it.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mssql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
