### PR TITLE
check for propertyType object

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -508,6 +508,14 @@ MsSQL.prototype.applyPagination =
 
 MsSQL.prototype.buildExpression = function(columnName, operator, operatorValue,
   propertyDefinition) {
+    
+  if(propertyDefinition.type.name === 'Object'){
+
+    operatorValue = operatorValue.slice(1, -1)
+    
+  }
+  
+    
   switch (operator) {
     case 'like':
       return new ParameterizedSQL(columnName + " LIKE ? ESCAPE '\\'",


### PR DESCRIPTION
Add a propertyDefinition type check for Object and then remove the double-quote that came from stringifying the object.
This will allow the `like` operator in Loopback Filter to work for `stringified` object string. 
## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ / ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ /  ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
