### PR TITLE
Change/object stringify like operator

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -509,7 +509,7 @@ MsSQL.prototype.applyPagination =
 MsSQL.prototype.buildExpression = function(columnName, operator, operatorValue,
   propertyDefinition) {
     
-  if(propertyDefinition.type.name === 'Object'){
+  if(propertyDefinition.type.name === 'Object' || typeof(propertyDefinition.type) === 'object'){
 
     operatorValue = operatorValue.slice(1, -1)
     

--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -508,6 +508,14 @@ MsSQL.prototype.applyPagination =
 
 MsSQL.prototype.buildExpression = function(columnName, operator, operatorValue,
   propertyDefinition) {
+    
+  if(propertyDefinition.type.name === 'Object'){
+
+    operatorValue = operatorValue.slice(1, -1)
+    
+  }
+  
+    
   switch (operator) {
     case 'like':
       return new ParameterizedSQL(columnName + " LIKE ? ESCAPE '\\'",


### PR DESCRIPTION
In SQL database, object and array are `stringify` before it goes into the table. Using the `like` operator in loopback filter would not work since the like value will get stringify.
Modified the code to check for propertyDefinition Object and Array to remove the double-quote from the JSON.stringify(). 

## Checklist

- [/ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [/ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ /] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ /] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
